### PR TITLE
Add grunt cli as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "babelify": "7.2.0",
     "grunt": "0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-filesize": "0.0.7",
     "grunt-mocha-istanbul": "3.0.1",


### PR DESCRIPTION
It seems grunt-cli was missing, not allowing to run tests (even if tests are empty right now).